### PR TITLE
replace --docker-image with --image for oc new-build command

### DIFF
--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -76,7 +76,7 @@ spec:
               done
 
               # run build
-              oc -n "${NS}" new-build --name="${JOB_PREFIX}" --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13
+              oc -n "${NS}" new-build --name="${JOB_PREFIX}" --binary --strategy source --image registry.redhat.io/ubi8/go-toolset:1.17.7-13
               mkdir -p /tmp/build
               cat <<EOF > /tmp/build/go.mod
               module openshift/managed-cluster-config/sre-build-test


### PR DESCRIPTION
--docker-image has been deprecated, thus oc is throwing an error
```
namespace/openshift-build-test-27762311-ckjd8 created                                                                                                                                          
Flag --docker-image has been deprecated, Deprecated flag use --image                                                                                                                           
warning: Cannot find git. Ensure that it is installed and in your path. Git is required to work with git repositories.                                                                         
error: can't lookup images: imagestreamimports.image.openshift.io is forbidden: User "system:serviceaccount:openshift-build-test:sre-build-test" cannot create resource "imagestreamimports" in
error: unable to locate any local docker images with name "registry.redhat.io/ubi8/go-toolset:1.17.7-13"                                                                                       
                                                                                                                                                                                               
The 'oc new-build' command will match arguments to the following types:                                                                                                                        
                                                                                                                                                                                               
  1. Images tagged into image streams in the current project or the 'openshift' project                                                                                                        
     - if you don't specify a tag, we'll add ':latest'                                                                                                                                         
  2. Images in the container registry, on remote registries, or on the local container engine                                                                                                  
  3. Git repository URLs or local paths that point to Git repositories                                                                                                                         
                                                                                                                                                                                               
--allow-missing-images can be used to force the use of an image that was not matched                                                                                                                                                                                                                
```

/hold to verify if --image flag is available in older `oc` versions
